### PR TITLE
add full example with status

### DIFF
--- a/deployment-guide/docker-compose-files/dashboard-status-compose.yaml
+++ b/deployment-guide/docker-compose-files/dashboard-status-compose.yaml
@@ -1,0 +1,109 @@
+name: dashboard
+services:
+  coordinator:
+    image: digitalcredentials/workflow-coordinator:1.0.0
+    container_name: "ad-coordinator"
+    environment:
+      - ENABLE_STATUS_SERVICE=true
+      - PUBLIC_EXCHANGE_HOST=https://${HOST}/api
+      - TENANT_TOKEN_LEF_TEST=UNPROTECTED
+      - VIRTUAL_HOST=${HOST}
+      - VIRTUAL_PATH=/status
+      - VIRTUAL_PORT=4005
+      - LETSENCRYPT_HOST=${HOST}
+    ports:
+      - "4005:4005"
+  signing:
+    image: digitalcredentials/signing-service:1.0.0
+    container_name: "ad-signing"
+    environment:
+      - TENANT_SEED_LEF_TEST=z1AeiPT496wWmo9BG2QYXeTusgFSZPNG3T9wNeTtjrQ3rCB
+  transactions:
+    image: digitalcredentials/transaction-service:0.2.0
+    container_name: "ad-transactions"
+  status:
+    image: digitalcredentials/status-service-db:0.1.0
+    container_name: "ad-status"
+    environment:
+      - STATUS_CRED_SITE_ORIGIN=https://${HOST}/status
+      - CRED_STATUS_SERVICE=mongodb
+      - CRED_STATUS_DB_URL=mongodb+srv://your-mongo-user:your-mongo-password@cluster0.8s9a0.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
+      - CRED_STATUS_DID_SEED=z1AeiPT496wWmo9BG2QYXeTusgFSZPNG3T9wNeTtjrQ3rCB
+    ports:
+      - "4008:4008"
+  payload:
+    image: digitalcredentials/dcc-admin-dashboard:1.0.0
+    container_name: "ad-payload"
+    depends_on: 
+      - coordinator
+      - redis
+    environment:
+      - COORDINATOR_URL=http://coordinator:4005
+      - STATUS_URL=http://status:4008
+      - REDIS_URL=redis
+      - REDIS_PORT=6379
+      - MONGODB_URI=mongodb+srv://your-mongo-user:your-mongo-password@cluster0.8s9a0.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
+      - PAYLOAD_SECRET=aaaaaaaaaaaaaaaaaaaaaaaa
+      - TENANT_NAME=lef_test
+      - SMTP_HOST=your-smtp-host
+      - SMTP_USER=your-smtp-user
+      - SMTP_PASS=your-smpt-password
+      - EMAIL_FROM=Digital Credentials Consortium Demo Isser <from email address - keep the '<' and '>'>
+      - CLAIM_PAGE_URL=https://${HOST}/claim
+      - PAYLOAD_PUBLIC_SERVER_URL=https://${HOST}
+      - VIRTUAL_HOST=${HOST}
+      - VIRTUAL_PATH=/
+      - VIRTUAL_PORT=3000
+      - LETSENCRYPT_HOST=${HOST}
+    ports:
+      - "3000:3000"
+  claim-page:
+    image: digitalcredentials/admin-dashboard-claim-page:1.1.0
+    container_name: "ad-claim-page"
+    environment:
+      - VIRTUAL_HOST=${HOST}
+      - VIRTUAL_PATH=/claim
+      - VIRTUAL_DEST=/
+      - VIRTUAL_PORT=8080
+      - PUBLIC_PAYLOAD_URL=https://${HOST}/api
+      - LETSENCRYPT_HOST=${HOST}
+    depends_on: 
+      - payload
+    ports:
+      - "8080:8080"
+  redis:
+    image: redis:alpine
+    container_name: ad-redis
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    ports:
+      - "6379:6379"
+  nginx-proxy:
+    image: nginxproxy/nginx-proxy
+    container_name: "ad-nginx"
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - html:/usr/share/nginx/html
+      - certs:/etc/nginx/certs
+      - vhost:/etc/nginx/vhost.d
+  nginx-proxy-acme:
+    image: nginxproxy/acme-companion
+    container_name: "ad-nginx-proxy"
+    volumes_from:
+      - nginx-proxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - acme:/etc/acme.sh
+    environment:
+      - DEFAULT_EMAIL=some.email@example.org
+volumes:
+  transactions:
+  mongo_data:
+  vhost:
+  html:
+  certs:
+  acme:


### PR DESCRIPTION
adds a new compose example showing how to use with mongo status service.

TODO: update deployment guide to describe how to use this example compose, i.e, setting mail and mongo ends